### PR TITLE
chore(build): fix dotnet build

### DIFF
--- a/Veso.Api/Auth/CustomAuthenticationHandler.cs
+++ b/Veso.Api/Auth/CustomAuthenticationHandler.cs
@@ -1,11 +1,11 @@
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
-using Veso.Api.Constants;
 using MediaBrowser.Controller.Net;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Veso.Api.Constants;
 
 namespace Veso.Api.Auth
 {

--- a/Veso.Api/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandler.cs
+++ b/Veso.Api/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandler.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
-using Veso.Api.Constants;
 using MediaBrowser.Common.Configuration;
 using Microsoft.AspNetCore.Authorization;
+using Veso.Api.Constants;
 
 namespace Veso.Api.Auth.FirstTimeSetupOrElevatedPolicy
 {

--- a/Veso.Api/Auth/RequiresElevationPolicy/RequiresElevationHandler.cs
+++ b/Veso.Api/Auth/RequiresElevationPolicy/RequiresElevationHandler.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
-using Veso.Api.Constants;
 using Microsoft.AspNetCore.Authorization;
+using Veso.Api.Constants;
 
 namespace Veso.Api.Auth.RequiresElevationPolicy
 {

--- a/Veso.Api/Controllers/StartupController.cs
+++ b/Veso.Api/Controllers/StartupController.cs
@@ -1,11 +1,11 @@
 using System.Linq;
 using System.Threading.Tasks;
-using Veso.Api.Constants;
-using Veso.Api.Models.StartupDtos;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Veso.Api.Constants;
+using Veso.Api.Models.StartupDtos;
 
 namespace Veso.Api.Controllers
 {

--- a/Veso.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Veso.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -1,13 +1,13 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Veso.Api;
 using Veso.Api.Auth;
 using Veso.Api.Auth.FirstTimeSetupOrElevatedPolicy;
 using Veso.Api.Auth.RequiresElevationPolicy;
 using Veso.Api.Constants;
 using Veso.Api.Controllers;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
 
 namespace Veso.Server.Extensions
 {

--- a/Veso.Server/Program.cs
+++ b/Veso.Server/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -15,10 +14,8 @@ using Emby.Drawing;
 using Emby.Server.Implementations;
 using Emby.Server.Implementations.IO;
 using Emby.Server.Implementations.Networking;
-using Veso.Drawing.Skia;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Drawing;
-using MediaBrowser.Model.Globalization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,9 +23,9 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Serilog;
-using Serilog.Events;
 using Serilog.Extensions.Logging;
 using SQLitePCL;
+using Veso.Drawing.Skia;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Veso.Server

--- a/Veso.Server/Startup.cs
+++ b/Veso.Server/Startup.cs
@@ -1,10 +1,10 @@
-using Veso.Server.Extensions;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Veso.Server.Extensions;
 
 namespace Veso.Server
 {


### PR DESCRIPTION
Stylecop is asking for namespaces to be put in alphabetical order, which is breaking the build because of the rename of the project.

This PR fixes the namespace order errors so we can build.